### PR TITLE
Remove plain_fsm as dependency on rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,8 +13,6 @@
 %%=============================================================================
 {erl_first_files, ["src/locks_watcher.erl", "src/locks_leader.erl"]}.
 {sub_dirs, ["examples"]}.
-{deps, [{plain_fsm,".*",{git,"git://github.com/uwiger/plain_fsm.git",
-			 {branch, master}}}]}.
 {edoc_opts, [{doclet, edown_doclet},
              {app_default, "http://www.erlang.org/doc/man"},
              {doc_path, []},


### PR DESCRIPTION
I was reading through gproc, locks_leader and other parts of locks code and realized that `plain_fsm` is not being used on the project. The tests are passing and I can't find anything related to `plain_fsm` whatsoever.