### PR TITLE
Re-check after DOWN when non-leader node appears

### DIFF
--- a/src/locks_agent.erl
+++ b/src/locks_agent.erl
@@ -803,7 +803,11 @@ handle_nodedown(Node, #state{down = Down, requests = Reqs,
                         true  -> watch_node(Node);
                         false -> ignore
                     end,
-                    {noreply, S1}
+                    if PRs =/= [] ->
+                            {noreply, check_if_done(S1)};
+                       true ->
+                            {noreply, S1}
+                    end
             end
     end.
 


### PR DESCRIPTION
Re. #11 - force a check_if_done() after DOWN if there are related requests and await_nodes == true. This should ensure that e.g. locks_leader gets notified and can proceed.