### PR TITLE
Add async case to reply_await_/2

### DIFF
--- a/src/locks_agent.erl
+++ b/src/locks_agent.erl
@@ -950,6 +950,8 @@ notify_have_all(#state{awaiting_all = Aw, status = Status} = S) ->
 
 reply_await_({Pid, notify}, Status) ->
     notify_(Pid, Status);
+reply_await_({Pid, async}, Status) ->
+    notify_(Pid, Status);
 reply_await_(From, Status) ->
     gen_server:reply(From, Status).
 


### PR DESCRIPTION
This is needed to support locks_agent:async_await_all_locks/1,
to ensure the notification will be correctly sent to the caller.

Note, that this will help to partially mitigate https://github.com/uwiger/locks/issues/30, fixing one of the possible causes, but won't solve the issue entirely, since its the root cause is the locks_leader design specifics.