### PR TITLE
Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-
-
 # The locks application #
+
+[![CI](https://github.com/uwiger/locks/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/uwiger/locks/actions/workflows/ci.yml)
 
 __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)), Thomas Arts ([`thomas@quviq.com`](mailto:thomas@quviq.com)).
 


### PR DESCRIPTION
Show the GitHub Actions CI workflow status for the master branch on the project front page.